### PR TITLE
feat: AccessToken 갱신

### DIFF
--- a/src/main/java/com/swp/auth/JwtAuthenticationFilter.java
+++ b/src/main/java/com/swp/auth/JwtAuthenticationFilter.java
@@ -9,10 +9,12 @@ import javax.servlet.http.HttpServletResponse;
 
 import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.Authentication;
-import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.util.StringUtils;
 import org.springframework.web.filter.OncePerRequestFilter;
+
+import com.swp.auth.exception.TokenException;
+import com.swp.common.exception.ApiException;
 
 import lombok.RequiredArgsConstructor;
 
@@ -34,8 +36,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 			SecurityContextHolder.getContext().setAuthentication(authentication);
 
 			filterChain.doFilter(request, response);
-		} catch (AuthenticationException e) {
-			authenticationEntryPoint.commence(request, response, e);
+		} catch (ApiException e) {
+			authenticationEntryPoint.commence(request, response, new TokenException(e.getMessage()));
 		}
 	}
 

--- a/src/main/java/com/swp/auth/JwtProvider.java
+++ b/src/main/java/com/swp/auth/JwtProvider.java
@@ -14,8 +14,8 @@ import org.springframework.stereotype.Component;
 import com.swp.auth.dto.JwtUserDetails;
 import com.swp.auth.dto.TokenRequestDto;
 import com.swp.auth.dto.TokenResponseDto;
+import com.swp.auth.exception.ExpiredTokenException;
 import com.swp.auth.exception.InvalidTokenException;
-import com.swp.auth.exception.TokenException;
 
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.ExpiredJwtException;
@@ -87,32 +87,30 @@ public class JwtProvider {
 		try {
 			parseJws(token, accessTokenSecret);
 		} catch (ExpiredJwtException e) {
-			throw new TokenException("만료된 토큰입니다");
-		} catch (UnsupportedJwtException | MalformedJwtException | SignatureException e) {
-			throw new TokenException("비정상적인 토큰입니다");
-		} catch (IllegalArgumentException e) {
-			throw new TokenException("토큰이 비어있습니다");
-		}
-	}
-
-	private boolean isTokenValid(String token, Key key) {
-		try {
-			parseJws(token, key);
-		} catch (ExpiredJwtException e) {
-			return false;
+			throw new ExpiredTokenException("만료된 토큰입니다");
 		} catch (UnsupportedJwtException | MalformedJwtException | SignatureException e) {
 			throw new InvalidTokenException("비정상적인 토큰입니다");
 		} catch (IllegalArgumentException e) {
 			throw new InvalidTokenException("토큰이 비어있습니다");
 		}
-		return true;
+	}
+
+	public void validate(String token, Key key) {
+		try {
+			parseJws(token, key);
+		} catch (ExpiredJwtException e) {
+			throw new ExpiredTokenException("만료된 토큰입니다");
+		} catch (UnsupportedJwtException | MalformedJwtException | SignatureException e) {
+			throw new InvalidTokenException("비정상적인 토큰입니다");
+		} catch (IllegalArgumentException e) {
+			throw new InvalidTokenException("토큰이 비어있습니다");
+		}
 	}
 
 	public TokenResponseDto renewToken(TokenRequestDto requestDto) {
 		String refreshToken = requestDto.getRefreshToken();
 		String accessToken;
-		if (!isTokenValid(requestDto.getRefreshToken(), refreshTokenSecret))
-			throw new InvalidTokenException("리프레쉬 토큰이 만료되었습니다");
+		validate(requestDto.getRefreshToken(), refreshTokenSecret);
 
 		Claims AccessTokenClaims = parseJws(requestDto.getRefreshToken(), refreshTokenSecret).getBody();
 		Claims RefreshTokenClaims = parseJws(requestDto.getRefreshToken(), refreshTokenSecret).getBody();

--- a/src/main/java/com/swp/auth/JwtProvider.java
+++ b/src/main/java/com/swp/auth/JwtProvider.java
@@ -34,15 +34,15 @@ public class JwtProvider {
 	private static final String PROVIDER_KEY = "provider";
 	private final Key accessTokenSecret;
 	private final Key refreshTokenSecret;
-	@Value("${app.auth.tokenExpiry}")
+	@Value("${app.auth.accessTokenExpiry}")
 	private Long accessTokenExpiry;
 	@Value("${app.auth.refreshTokenExpiry}")
 	private Long refreshTokenExpiry;
 	@Value("${app.auth.refreshTokenNearExpiryCriterion}")
 	private Long refreshTokenExpiryCriterion;
 
-	public JwtProvider(@Value("${app.auth.jwtSecret}") String accessTokenSecret,
-		@Value("${app.auth.jwtRefreshSecret}") String refreshTokenSecret) {
+	public JwtProvider(@Value("${app.auth.accessTokenSecret}") String accessTokenSecret,
+		@Value("${app.auth.refreshTokenSecret}") String refreshTokenSecret) {
 		byte[] secretBytes = Base64.getEncoder().encode(accessTokenSecret.getBytes(StandardCharsets.UTF_8));
 		this.accessTokenSecret = Keys.hmacShaKeyFor(secretBytes);
 		secretBytes = Base64.getEncoder().encode(refreshTokenSecret.getBytes(StandardCharsets.UTF_8));
@@ -109,14 +109,8 @@ public class JwtProvider {
 	}
 
 	public TokenResponseDto renewToken(TokenRequestDto requestDto) {
-		String accessToken = requestDto.getAccessToken();
 		String refreshToken = requestDto.getRefreshToken();
-		if (isTokenValid(accessToken, accessTokenSecret))
-			return TokenResponseDto.builder()
-				.accessToken(accessToken)
-				.refreshToken(refreshToken)
-				.build();
-
+		String accessToken;
 		if (!isTokenValid(requestDto.getRefreshToken(), refreshTokenSecret))
 			throw new InvalidTokenException("리프레쉬 토큰이 만료되었습니다");
 

--- a/src/main/java/com/swp/auth/controller/AuthController.java
+++ b/src/main/java/com/swp/auth/controller/AuthController.java
@@ -17,7 +17,7 @@ public class AuthController {
 
 	private final JwtProvider jwtProvider;
 
-	@PostMapping(path = "/login/renew")
+	@PostMapping(path = "/v1/auth/renew")
 	public TokenResponseDto renewToken(@RequestBody TokenRequestDto requestDto) {
 		return jwtProvider.renewToken(requestDto);
 	}

--- a/src/main/java/com/swp/auth/controller/AuthController.java
+++ b/src/main/java/com/swp/auth/controller/AuthController.java
@@ -1,0 +1,24 @@
+package com.swp.auth.controller;
+
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.swp.auth.JwtProvider;
+import com.swp.auth.dto.TokenRequestDto;
+import com.swp.auth.dto.TokenResponseDto;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@RestController
+public class AuthController {
+
+	private final JwtProvider jwtProvider;
+
+	@PostMapping(path = "/login/renew")
+	public TokenResponseDto renewToken(@RequestBody TokenRequestDto requestDto) {
+		return jwtProvider.renewToken(requestDto);
+	}
+}

--- a/src/main/java/com/swp/auth/dto/TokenRequestDto.java
+++ b/src/main/java/com/swp/auth/dto/TokenRequestDto.java
@@ -11,6 +11,5 @@ import lombok.NoArgsConstructor;
 @Builder
 public class TokenRequestDto {
 
-	private String accessToken;
 	private String refreshToken;
 }

--- a/src/main/java/com/swp/auth/dto/TokenRequestDto.java
+++ b/src/main/java/com/swp/auth/dto/TokenRequestDto.java
@@ -1,0 +1,16 @@
+package com.swp.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+public class TokenRequestDto {
+
+	private String accessToken;
+	private String refreshToken;
+}

--- a/src/main/java/com/swp/auth/exception/ExpiredTokenException.java
+++ b/src/main/java/com/swp/auth/exception/ExpiredTokenException.java
@@ -1,0 +1,10 @@
+package com.swp.auth.exception;
+
+import com.swp.common.exception.UnauthorizedException;
+
+public class ExpiredTokenException extends UnauthorizedException {
+
+	public ExpiredTokenException(String msg) {
+		super(msg);
+	}
+}

--- a/src/main/java/com/swp/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/swp/auth/exception/InvalidTokenException.java
@@ -1,8 +1,8 @@
 package com.swp.auth.exception;
 
-import com.swp.common.exception.BadRequestException;
+import com.swp.common.exception.UnauthorizedException;
 
-public class InvalidTokenException extends BadRequestException {
+public class InvalidTokenException extends UnauthorizedException {
 
 	public InvalidTokenException(String message) {
 		super(message);

--- a/src/main/java/com/swp/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/swp/auth/exception/InvalidTokenException.java
@@ -1,0 +1,10 @@
+package com.swp.auth.exception;
+
+import com.swp.common.exception.BadRequestException;
+
+public class InvalidTokenException extends BadRequestException {
+
+	public InvalidTokenException(String message) {
+		super(message);
+	}
+}

--- a/src/main/java/com/swp/config/SecurityConfig.java
+++ b/src/main/java/com/swp/config/SecurityConfig.java
@@ -1,6 +1,8 @@
 package com.swp.config;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -25,6 +27,11 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
 	@Override
+	public void configure(WebSecurity web) throws Exception {
+		web.ignoring().antMatchers("/login/renew");
+	}
+
+	@Override
 	protected void configure(HttpSecurity http) throws Exception {
 		http.cors()
 			.and()
@@ -40,12 +47,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 			.and()
 			.authorizeRequests()
-			.antMatchers("/v1/**")
-			.hasRole(Role.USER.toString())
-			.antMatchers("/login/**")
-			.permitAll()
-			.anyRequest()
-			.authenticated()
+			.antMatchers("/v1/**").hasRole(Role.USER.toString())
+			.anyRequest().authenticated()
 			.and()
 
 			.oauth2Login()

--- a/src/main/java/com/swp/config/SecurityConfig.java
+++ b/src/main/java/com/swp/config/SecurityConfig.java
@@ -28,7 +28,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Override
 	public void configure(WebSecurity web) throws Exception {
-		web.ignoring().mvcMatchers(HttpMethod.POST, "/login/renew");
+		web.ignoring().mvcMatchers(HttpMethod.POST, "/v1/auth/renew");
 	}
 
 	@Override

--- a/src/main/java/com/swp/config/SecurityConfig.java
+++ b/src/main/java/com/swp/config/SecurityConfig.java
@@ -1,6 +1,6 @@
 package com.swp.config;
 
-import org.springframework.core.annotation.Order;
+import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -28,7 +28,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Override
 	public void configure(WebSecurity web) throws Exception {
-		web.ignoring().antMatchers("/login/renew");
+		web.ignoring().mvcMatchers(HttpMethod.POST, "/login/renew");
 	}
 
 	@Override

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,5 +20,7 @@ spring:
 
 app.auth:
   jwtSecret: ${TOKEN_SECRET}
+  jwtRefreshSecret: ${REFRESH_SECRET}
   tokenExpiry: 86400000
   refreshTokenExpiry: 604800000
+  refreshTokenNearExpiryCriterion: 259200000

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,8 +19,8 @@ spring:
 
 
 app.auth:
-  jwtSecret: ${TOKEN_SECRET}
-  jwtRefreshSecret: ${REFRESH_SECRET}
-  tokenExpiry: 86400000
+  accessTokenSecret: ${ACCESS_TOKEN_SECRET}
+  refreshTokenSecret: ${REFRESH_TOKEN_SECRET}
+  accessTokenExpiry: 86400000
   refreshTokenExpiry: 604800000
   refreshTokenNearExpiryCriterion: 259200000

--- a/src/test/java/com/swp/auth/JwtProviderTest.java
+++ b/src/test/java/com/swp/auth/JwtProviderTest.java
@@ -1,0 +1,185 @@
+package com.swp.auth;
+
+import static org.assertj.core.api.Assertions.*;
+
+import java.nio.charset.StandardCharsets;
+import java.security.Key;
+import java.util.Base64;
+import java.util.Date;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.core.Authentication;
+
+import com.swp.auth.dto.TokenRequestDto;
+import com.swp.auth.dto.TokenResponseDto;
+import com.swp.auth.exception.InvalidTokenException;
+import com.swp.auth.exception.TokenException;
+import com.swp.user.domain.Role;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jws;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.security.Keys;
+
+@SpringBootTest
+class JwtProviderTest {
+
+	@Autowired
+	private JwtProvider jwtProvider;
+	private final Key accessTokenSecret;
+	private final Key refreshTokenSecret;
+	private TokenResponseDto responseDto;
+	private static final String providerExpected = "kakao";
+	private static final String providerIdExpected = "12333333";
+	private static final String roleExpected = Role.USER.toString();
+
+	public JwtProviderTest(@Value("${app.auth.jwtSecret}") String accessTokenSecret,
+		@Value("${app.auth.jwtRefreshSecret}") String refreshTokenSecret) {
+		byte[] secretBytes = Base64.getEncoder().encode(accessTokenSecret.getBytes(StandardCharsets.UTF_8));
+		this.accessTokenSecret = Keys.hmacShaKeyFor(secretBytes);
+		secretBytes = Base64.getEncoder().encode(refreshTokenSecret.getBytes(StandardCharsets.UTF_8));
+		this.refreshTokenSecret = Keys.hmacShaKeyFor(secretBytes);
+	}
+
+	private Jws<Claims> parseJws(String token, Key key) {
+		return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+	}
+
+	private String getExpiredToken() {
+		Claims claims = Jwts.claims();
+		claims.setSubject(providerIdExpected);
+		claims.put("provider", providerExpected);
+		claims.put("role", roleExpected);
+		Date now = new Date();
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() - 1))
+			.signWith(accessTokenSecret, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	private String getExpiredRefreshToken() {
+		Claims claims = Jwts.claims();
+		claims.setSubject(providerIdExpected);
+		claims.put("provider", providerExpected);
+		claims.put("role", roleExpected);
+		Date now = new Date();
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() - 1))
+			.signWith(refreshTokenSecret, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	private String getNearExpiryRefreshToken() {
+		Claims claims = Jwts.claims();
+		claims.setSubject(providerIdExpected);
+		claims.put("provider", providerExpected);
+		claims.put("role", roleExpected);
+		Date now = new Date();
+
+		return Jwts.builder()
+			.setClaims(claims)
+			.setIssuedAt(now)
+			.setExpiration(new Date(now.getTime() + 3600 * 1000))
+			.signWith(refreshTokenSecret, SignatureAlgorithm.HS512)
+			.compact();
+	}
+
+	@BeforeEach
+	void setUp() {
+		this.responseDto = jwtProvider.createToken(providerExpected, providerIdExpected, roleExpected);
+	}
+
+	@Test
+	void createToken() {
+		// given, when
+		Claims accessTokenClaims = parseJws(responseDto.getAccessToken(), accessTokenSecret).getBody();
+		Claims refreshTokenClaims = parseJws(responseDto.getRefreshToken(), refreshTokenSecret).getBody();
+		// then
+		assertThat(accessTokenClaims.getSubject()).isEqualTo(providerIdExpected);
+		assertThat(accessTokenClaims.get("provider")).isEqualTo(providerExpected);
+		assertThat(accessTokenClaims.get("role")).isEqualTo(roleExpected);
+		assertThat(refreshTokenClaims.getSubject()).isEqualTo(providerIdExpected);
+		assertThat(refreshTokenClaims.get("provider")).isEqualTo(providerExpected);
+		assertThat(refreshTokenClaims.get("role")).isEqualTo(roleExpected);
+	}
+
+	@Test
+	void getAuthentication() {
+		// given, when
+		Authentication authentication = jwtProvider.getAuthentication(responseDto.getAccessToken());
+		// then
+		assertThat(authentication.getAuthorities().size()).isEqualTo(1);
+		assertThat(authentication.getName()).isEqualTo(providerIdExpected);
+	}
+
+	@Test
+	void validateEmptyToken() {
+		assertThatThrownBy(() -> jwtProvider.validate(null))
+			.isInstanceOf(TokenException.class)
+			.hasMessageContaining("비어있습니다");
+	}
+
+	@Test
+	void validateInvalidToken() {
+		assertThatThrownBy(() -> jwtProvider.validate("IAMINVALIDTOKEN"))
+			.isInstanceOf(TokenException.class)
+			.hasMessageContaining("비정상");
+	}
+
+	@Test
+	void validateExpiredToken() {
+		assertThatThrownBy(() -> jwtProvider.validate(getExpiredToken()))
+			.isInstanceOf(TokenException.class)
+			.hasMessageContaining("만료");
+	}
+
+	@Test
+	void renewTokenAccessTokenExpired() {
+		// given, when
+		TokenRequestDto requestDto = TokenRequestDto.builder()
+			.accessToken(getExpiredToken())
+			.refreshToken(responseDto.getRefreshToken())
+			.build();
+		TokenResponseDto renewedToken = jwtProvider.renewToken(requestDto);
+		// then
+		assertThat(renewedToken.getAccessToken()).isNotEqualTo(requestDto.getAccessToken());
+		assertThat(renewedToken.getRefreshToken()).isEqualTo(requestDto.getRefreshToken());
+	}
+
+	@Test
+	void renewTokenRefreshTokenNearExpiry() {
+		// given, when
+		TokenRequestDto requestDto = TokenRequestDto.builder()
+			.accessToken(getExpiredToken())
+			.refreshToken(getNearExpiryRefreshToken())
+			.build();
+		TokenResponseDto renewedToken = jwtProvider.renewToken(requestDto);
+		// then
+		assertThat(renewedToken.getAccessToken()).isNotEqualTo(requestDto.getAccessToken());
+		assertThat(renewedToken.getRefreshToken()).isNotEqualTo(requestDto.getRefreshToken());
+	}
+
+	@Test
+	void renewTokenBothExpired() {
+		// given, when
+		TokenRequestDto requestDto = TokenRequestDto.builder()
+			.accessToken(getExpiredToken())
+			.refreshToken(getExpiredRefreshToken())
+			.build();
+		// then
+		assertThatThrownBy(()->jwtProvider.renewToken(requestDto))
+			.isInstanceOf(InvalidTokenException.class)
+			.hasMessageContaining("만료");
+	}
+}


### PR DESCRIPTION
`RefreshToken`을 사용한 `AccessToken` 갱신을 구현했고 `JwtProvider`의 테스트를 작성했습니다.
`RefreshToken`과 `AccessToken`의 `secret key`를 다르게 사용하도록 구현하였으며
`RefreshToken`의 만료가 **3일 이내**라면 `RefreshToken`도 함께 갱신하도록 하였습니다.
오류는 `BadRequestException`을 상속하는 `InvalidTokenException`을 작성하여 각종 오류를 처리하도록 하였습니다.

endpoint는 `/login/renew` 입니다.