### PR TITLE
feat: oAuth2 로그인 redirect-uri 지정

### DIFF
--- a/src/main/java/com/swp/config/SecurityConfig.java
+++ b/src/main/java/com/swp/config/SecurityConfig.java
@@ -11,6 +11,7 @@ import com.swp.auth.JwtAuthenticationEntryPoint;
 import com.swp.auth.JwtAuthenticationFilter;
 import com.swp.auth.JwtProvider;
 import com.swp.oauth.CookieOAuth2AuthorizationRequestRepository;
+import com.swp.oauth.OAuth2FailureHandler;
 import com.swp.oauth.OAuth2SuccessHandler;
 import com.swp.oauth.ThirdPartyOAuth2UserService;
 import com.swp.user.domain.Role;
@@ -23,6 +24,7 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	private final ThirdPartyOAuth2UserService thirdPartyOAuth2UserService;
 	private final OAuth2SuccessHandler successHandler;
+	private final OAuth2FailureHandler failureHandler;
 	private final JwtProvider jwtProvider;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 	private final CookieOAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
@@ -60,7 +62,8 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 			.userInfoEndpoint()
 			.userService(thirdPartyOAuth2UserService)
 			.and()
-			.successHandler(successHandler);
+			.successHandler(successHandler)
+			.failureHandler(failureHandler);
 
 		http.addFilterBefore(new JwtAuthenticationFilter(jwtProvider, jwtAuthenticationEntryPoint),
 			UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/com/swp/config/SecurityConfig.java
+++ b/src/main/java/com/swp/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.swp.config;
 
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -9,6 +10,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import com.swp.auth.JwtAuthenticationEntryPoint;
 import com.swp.auth.JwtAuthenticationFilter;
 import com.swp.auth.JwtProvider;
+import com.swp.oauth.CookieOAuth2AuthorizationRequestRepository;
 import com.swp.oauth.OAuth2SuccessHandler;
 import com.swp.oauth.ThirdPartyOAuth2UserService;
 import com.swp.user.domain.Role;
@@ -23,6 +25,13 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 	private final OAuth2SuccessHandler successHandler;
 	private final JwtProvider jwtProvider;
 	private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
+	private final CookieOAuth2AuthorizationRequestRepository oAuth2AuthorizationRequestRepository;
+
+	@Override
+
+	public void configure(WebSecurity web) throws Exception {
+		web.ignoring().antMatchers("/login/renew");
+	}
 
 	@Override
 	protected void configure(HttpSecurity http) throws Exception {
@@ -40,15 +49,14 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 			.and()
 			.authorizeRequests()
-			.antMatchers("/v1/**")
-			.hasRole(Role.USER.toString())
-			.antMatchers("/login/**")
-			.permitAll()
-			.anyRequest()
-			.authenticated()
+			.antMatchers("/v1/**").hasRole(Role.USER.toString())
+			.anyRequest().authenticated()
 			.and()
 
 			.oauth2Login()
+			.authorizationEndpoint()
+			.authorizationRequestRepository(oAuth2AuthorizationRequestRepository)
+			.and()
 			.userInfoEndpoint()
 			.userService(thirdPartyOAuth2UserService)
 			.and()

--- a/src/main/java/com/swp/oauth/CookieOAuth2AuthorizationRequestRepository.java
+++ b/src/main/java/com/swp/oauth/CookieOAuth2AuthorizationRequestRepository.java
@@ -1,0 +1,53 @@
+package com.swp.oauth;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+import com.nimbusds.oauth2.sdk.util.StringUtils;
+import com.swp.util.CookieUtils;
+
+@Component
+public class CookieOAuth2AuthorizationRequestRepository
+	implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+	public static final String OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME = "oauth2_auth_request";
+	public static final String REDIRECT_URI_PARAM_COOKIE_NAME = "redirect-uri";
+	private static final int cookieExpireSeconds = 180;
+
+	@Override
+	public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+		return CookieUtils.getCookie(request, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME)
+			.map(cookie -> CookieUtils.deserialize(cookie, OAuth2AuthorizationRequest.class))
+			.orElse(null);
+	}
+
+	@Override
+	public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest, HttpServletRequest request,
+		HttpServletResponse response) {
+		if (authorizationRequest == null) {
+			CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+			CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+			return;
+		}
+
+		CookieUtils.addCookie(response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME,
+			CookieUtils.serialize(authorizationRequest), cookieExpireSeconds);
+		String redirectUriAfterLogin = request.getParameter(REDIRECT_URI_PARAM_COOKIE_NAME);
+		if (StringUtils.isNotBlank(redirectUriAfterLogin)) {
+			CookieUtils.addCookie(response, REDIRECT_URI_PARAM_COOKIE_NAME, redirectUriAfterLogin, cookieExpireSeconds);
+		}
+	}
+
+	@Override
+	public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request) {
+		return this.loadAuthorizationRequest(request);
+	}
+
+	public void removeAuthorizationRequestCookies(HttpServletRequest request, HttpServletResponse response) {
+		CookieUtils.deleteCookie(request, response, OAUTH2_AUTHORIZATION_REQUEST_COOKIE_NAME);
+		CookieUtils.deleteCookie(request, response, REDIRECT_URI_PARAM_COOKIE_NAME);
+	}
+}

--- a/src/main/java/com/swp/oauth/OAuth2FailureHandler.java
+++ b/src/main/java/com/swp/oauth/OAuth2FailureHandler.java
@@ -1,0 +1,50 @@
+package com.swp.oauth;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+import org.springframework.stereotype.Component;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import com.swp.util.CookieUtils;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class OAuth2FailureHandler implements AuthenticationFailureHandler {
+
+	@Value("${frontend.redirectUri}")
+	private String REDIRECTION_URI;
+	@Value("${frontend.authorizedRedirectUris}")
+	private String[] AUTHORIZED_URIS;
+
+	private final CookieOAuth2AuthorizationRequestRepository requestRepository;
+
+	@Override
+	public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
+		AuthenticationException exception) throws IOException, ServletException {
+		requestRepository.removeAuthorizationRequestCookies(request, response);
+		response.sendRedirect(getTargetUrl(request));
+	}
+
+	private String getTargetUrl(HttpServletRequest request) {
+		Optional<String> redirectUri = CookieUtils.getCookie(request,
+			CookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME).map(Cookie::getValue);
+
+		if (redirectUri.isPresent() && redirectUri.stream()
+			.anyMatch(uri -> Arrays.asList(AUTHORIZED_URIS).contains(uri))) {
+			return UriComponentsBuilder.fromUriString(redirectUri.get()).build().toUriString();
+		}
+		return REDIRECTION_URI;
+	}
+}

--- a/src/main/java/com/swp/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swp/oauth/OAuth2SuccessHandler.java
@@ -33,12 +33,14 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 	@Value("${frontend.authorizedRedirectUris}")
 	private String[] AUTHORIZED_URIS;
 	private final JwtProvider jwtProvider;
+	private final CookieOAuth2AuthorizationRequestRepository requestRepository;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
 
+		requestRepository.removeAuthorizationRequestCookies(request, response);
 		response.sendRedirect(getTargetUrl(request, oAuth2User));
 	}
 

--- a/src/main/java/com/swp/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swp/oauth/OAuth2SuccessHandler.java
@@ -28,9 +28,9 @@ import lombok.RequiredArgsConstructor;
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
 	private static final String PROVIDER_KEY = "provider";
-	@Value("${frontend.redirect-uri}")
+	@Value("${frontend.redirectUri}")
 	private String REDIRECTION_URI;
-	@Value("${frontend.authorized-redirect-uris}")
+	@Value("${frontend.authorizedRedirectUris}")
 	private String[] AUTHORIZED_URIS;
 	private final JwtProvider jwtProvider;
 

--- a/src/main/java/com/swp/oauth/OAuth2SuccessHandler.java
+++ b/src/main/java/com/swp/oauth/OAuth2SuccessHandler.java
@@ -1,8 +1,11 @@
 package com.swp.oauth;
 
 import java.io.IOException;
+import java.util.Arrays;
+import java.util.Optional;
 
 import javax.servlet.ServletException;
+import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -16,6 +19,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 import com.swp.auth.JwtProvider;
 import com.swp.auth.dto.TokenResponseDto;
 import com.swp.user.domain.Role;
+import com.swp.util.CookieUtils;
 
 import lombok.RequiredArgsConstructor;
 
@@ -26,23 +30,35 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 	private static final String PROVIDER_KEY = "provider";
 	@Value("${frontend.redirect-uri}")
 	private String REDIRECTION_URI;
+	@Value("${frontend.authorized-redirect-uris}")
+	private String[] AUTHORIZED_URIS;
 	private final JwtProvider jwtProvider;
 
 	@Override
 	public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
 		Authentication authentication) throws IOException, ServletException {
 		OAuth2User oAuth2User = (OAuth2User)authentication.getPrincipal();
-		String provider = oAuth2User.getAttribute(PROVIDER_KEY);
 
+		response.sendRedirect(getTargetUrl(request, oAuth2User));
+	}
+
+	private String getTargetUrl(HttpServletRequest request, OAuth2User oAuth2User) {
+		String provider = oAuth2User.getAttribute(PROVIDER_KEY);
 		String providerId = oAuth2User.getName();
 		String role = Role.USER.getValue();
 		TokenResponseDto token = jwtProvider.createToken(provider, providerId, role);
 
-		String targetUrl = UriComponentsBuilder.fromUriString(REDIRECTION_URI)
-			.queryParam("accessToken", token.getAccessToken())
-			.queryParam("refreshToken", token.getRefreshToken())
-			.build()
-			.toUriString();
-		response.sendRedirect(targetUrl);
+		Optional<String> redirectUri = CookieUtils.getCookie(request,
+			CookieOAuth2AuthorizationRequestRepository.REDIRECT_URI_PARAM_COOKIE_NAME).map(Cookie::getValue);
+
+		if (redirectUri.isPresent() && redirectUri.stream()
+			.anyMatch(uri -> Arrays.asList(AUTHORIZED_URIS).contains(uri))) {
+			return UriComponentsBuilder.fromUriString(redirectUri.get())
+				.queryParam("accessToken", token.getAccessToken())
+				.queryParam("refreshToken", token.getRefreshToken())
+				.build()
+				.toUriString();
+		}
+		return REDIRECTION_URI;
 	}
 }

--- a/src/main/java/com/swp/util/CookieUtils.java
+++ b/src/main/java/com/swp/util/CookieUtils.java
@@ -1,0 +1,50 @@
+package com.swp.util;
+
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Optional;
+
+import javax.servlet.http.Cookie;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.springframework.util.SerializationUtils;
+
+public class CookieUtils {
+
+	public static Optional<Cookie> getCookie(HttpServletRequest request, String name) {
+		return Arrays.stream(request.getCookies())
+			.filter(cookie -> cookie.getName().equals(name))
+			.findFirst();
+	}
+
+	public static void addCookie(HttpServletResponse response, String name, String value, int maxAge) {
+		Cookie cookie = new Cookie(name, value);
+		cookie.setPath("/");
+		cookie.setHttpOnly(true);
+		cookie.setMaxAge(maxAge);
+		response.addCookie(cookie);
+	}
+
+	public static void deleteCookie(HttpServletRequest request, HttpServletResponse response, String name) {
+		Arrays.stream(request.getCookies())
+			.filter(cookie -> cookie.getName().equals(name))
+			.forEach(cookie -> {
+				cookie.setValue(null);
+				cookie.setPath("/");
+				cookie.setMaxAge(0);
+				response.addCookie(cookie);
+			});
+	}
+
+	public static String serialize(Object object) {
+		return Base64.getUrlEncoder()
+			.encodeToString(SerializationUtils.serialize(object));
+	}
+
+	public static <T> T deserialize(Cookie cookie, Class<T> cls) {
+		return cls.cast(SerializationUtils.deserialize(
+			Base64.getUrlDecoder().decode(cookie.getValue())));
+	}
+
+}

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -21,3 +21,6 @@ spring:
           user-name-attribute: id
 
 frontend.redirect-uri: http://localhost:3000/login/oauth2/code/kakao
+frontend.authorized-redirect-uris: >
+  http://localhost:3000/login/oauth2/code/kakao,
+  https://swp-9wp56ifkv-softwareproject2022n.vercel.app/login/oauth2/code/kakao

--- a/src/main/resources/application-oauth.yml
+++ b/src/main/resources/application-oauth.yml
@@ -20,7 +20,9 @@ spring:
           user-info-uri: https://kapi.kakao.com/v2/user/me
           user-name-attribute: id
 
-frontend.redirect-uri: http://localhost:3000/login/oauth2/code/kakao
-frontend.authorized-redirect-uris: >
-  http://localhost:3000/login/oauth2/code/kakao,
-  https://swp-9wp56ifkv-softwareproject2022n.vercel.app/login/oauth2/code/kakao
+frontend:
+  redirectUri: http://localhost:3000/login/oauth2/code/kakao
+  authorizedRedirectUris: >
+    http://localhost:3000/login/oauth2/code/kakao,
+    https://swp-9wp56ifkv-softwareproject2022n.vercel.app/login/oauth2/code/kakao,
+    http://swp2022.s3-website.ap-northeast-2.amazonaws.com/login/oauth2/code/kakao


### PR DESCRIPTION
로그인 요청을 httpOnly Cookie에 저장하여 client-side에서 `redirect-uri`를 지정하도록 하였습니다.

다음과 같이 사용됩니다.

**기존 방식**
`https://test.server.com/oauth2/authorization/kakao` 
-> 무조건 지정된 URI인 `http://localhost:3000/login/oauth2/code/kakao`로 최종 리다이렉션 됩니다.

**변경 후**
`https://test.server.com/oauth2/authorization/kakao?redirect-uri=https://front.end.com/login/oauth2/code/kakao`

redirect-uri를 지정하지 않으면 기존과 동일하게 redirection 되어 하위 호환성을 유지합니다.