### PR TITLE
feat: Swagger 도입

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,8 @@ dependencies {
     implementation('org.springframework.boot:spring-boot-starter-security')
     implementation('org.springframework.boot:spring-boot-starter-oauth2-client')
     implementation('org.springframework.boot:spring-boot-starter-validation')
+    implementation('io.springfox:springfox-boot-starter:3.0.0')
+    implementation('io.springfox:springfox-swagger-ui:3.0.0')
     implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
     runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'

--- a/src/main/java/com/swp/config/SecurityConfig.java
+++ b/src/main/java/com/swp/config/SecurityConfig.java
@@ -32,7 +32,10 @@ public class SecurityConfig extends WebSecurityConfigurerAdapter {
 
 	@Override
 	public void configure(WebSecurity web) throws Exception {
-		web.ignoring().mvcMatchers(HttpMethod.POST, "/v1/auth/renew");
+		web.ignoring()
+			.mvcMatchers(HttpMethod.POST, "/v1/auth/renew")
+			.mvcMatchers(HttpMethod.GET, "/v3/api-docs")
+			.mvcMatchers(HttpMethod.GET, "/docs", "/swagger-ui/**", "/swagger-resources/**");
 	}
 
 	@Override

--- a/src/main/java/com/swp/config/SwaggerConfig.java
+++ b/src/main/java/com/swp/config/SwaggerConfig.java
@@ -1,0 +1,58 @@
+package com.swp.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import org.springframework.web.servlet.config.annotation.ViewControllerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import springfox.documentation.builders.ApiInfoBuilder;
+import springfox.documentation.builders.PathSelectors;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+import springfox.documentation.swagger.web.DocExpansion;
+import springfox.documentation.swagger.web.UiConfiguration;
+import springfox.documentation.swagger.web.UiConfigurationBuilder;
+
+@Configuration
+@EnableWebMvc
+public class SwaggerConfig implements WebMvcConfigurer {
+
+	private static final String API_TITLE = "OStudy API";
+	private static final String API_DESCRIPTION = "OStudy API Document";
+	private static final String API_VERSION = "Version 1";
+
+	private ApiInfo createApiInfo() {
+		return new ApiInfoBuilder()
+			.title(API_TITLE)
+			.description(API_DESCRIPTION)
+			.version(API_VERSION)
+			.build();
+	}
+
+	@Bean
+	public UiConfiguration uiConfiguration() {
+		return UiConfigurationBuilder.builder()
+			.docExpansion(DocExpansion.LIST)
+			.build();
+	}
+
+	@Bean
+	public Docket docket() {
+		return new Docket(DocumentationType.OAS_30)
+			.apiInfo(createApiInfo())
+			.select()
+			.apis(RequestHandlerSelectors.withClassAnnotation(RestController.class))
+			.paths(PathSelectors.any())
+			.build();
+	}
+
+	@Override
+	public void addViewControllers(ViewControllerRegistry registry) {
+		registry.addRedirectViewController("/docs", "/swagger-ui/index.html");
+		registry.addRedirectViewController("/swagger-ui", "/swagger-ui/index.html");
+	}
+}


### PR DESCRIPTION
> <img width="550" alt="image" src="https://user-images.githubusercontent.com/39221443/168815640-8034108d-fabe-47a8-9b3d-c1fe5f8ef82c.png">
클릭하면 크게 보입니다

[`SpringFox`](https://github.com/springfox/springfox) 를 사용하였습니다.

그에 따라 `SecurityConfig`에  무시할 엔드포인트를 보수적으로 추가하였습니다.(`GET` Method Only)
`@RestController`를 사용하는 Class 만 문서에 보이도록 하였습니다.

`SwaggerConfig`가 `WebMvcConfigurer`를 구현하도록 하여 redirection 을 추가했습니다
- `/docs` -> `/swagger-ui/index.html`
- `/swagger-ui` -> `/swagger-ui/index.html`

**Swagger UI Path는 `/docs`, `/swagger-ui`, `/swagger-ui/index.html`  입니다.**