### PR TITLE
feat: 스터디 생성, 종료, 로그 삽입

### DIFF
--- a/src/main/java/com/swp/study/Exception/StudyFinishedException.java
+++ b/src/main/java/com/swp/study/Exception/StudyFinishedException.java
@@ -1,0 +1,12 @@
+package com.swp.study.Exception;
+
+import com.swp.common.exception.ConflictException;
+
+public class StudyFinishedException extends ConflictException {
+
+	private static final String MESSAGE = "이미 종료된 스터디입니다";
+
+	public StudyFinishedException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/swp/study/Exception/StudyUserNotMatchException.java
+++ b/src/main/java/com/swp/study/Exception/StudyUserNotMatchException.java
@@ -1,0 +1,12 @@
+package com.swp.study.Exception;
+
+import com.swp.common.exception.ForbiddenException;
+
+public class StudyUserNotMatchException extends ForbiddenException {
+
+	private static final String MESSAGE = "요청한 유저가 스터디 유저와 다릅니다";
+
+	public StudyUserNotMatchException() {
+		super(MESSAGE);
+	}
+}

--- a/src/main/java/com/swp/study/controller/StudyController.java
+++ b/src/main/java/com/swp/study/controller/StudyController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.swp.auth.dto.JwtUserDetails;
 import com.swp.study.domain.StudyService;
+import com.swp.study.dto.StudyFinishDto;
 import com.swp.study.dto.StudyLogPostDto;
 import com.swp.study.dto.StudyLogResponseDto;
 import com.swp.study.dto.StudyResponseDto;
@@ -42,11 +43,11 @@ public class StudyController {
 
 	@ApiOperation(value = "스터디 종료", notes = "서버 시각 기준 종료")
 	@PostMapping("/{studyId}/finish")
-	public StudyResponseDto finishStudy(@PathVariable Integer studyId) {
+	public StudyResponseDto finishStudy(@PathVariable Integer studyId, @RequestBody StudyFinishDto finishDto) {
 		JwtUserDetails userDetails = (JwtUserDetails)SecurityContextHolder.getContext()
 			.getAuthentication()
 			.getPrincipal();
-		return studyService.finishStudy(userDetails, studyId);
+		return studyService.finishStudy(userDetails, studyId, finishDto);
 	}
 
 	@ApiOperation(value = "스터디 로그 삽입", notes = "기록 시각, 집중도를 싣어야 합니다")

--- a/src/main/java/com/swp/study/controller/StudyController.java
+++ b/src/main/java/com/swp/study/controller/StudyController.java
@@ -1,15 +1,23 @@
 package com.swp.study.controller;
 
-import com.swp.study.domain.StudyService;
-import com.swp.study.dto.StudyLogResponseDto;
-import io.swagger.annotations.ApiOperation;
-import lombok.RequiredArgsConstructor;
+import java.util.List;
+
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import java.util.List;
+import com.swp.auth.dto.JwtUserDetails;
+import com.swp.study.domain.StudyService;
+import com.swp.study.dto.StudyLogPostDto;
+import com.swp.study.dto.StudyLogResponseDto;
+import com.swp.study.dto.StudyResponseDto;
+
+import io.swagger.annotations.ApiOperation;
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @RestController
@@ -21,5 +29,33 @@ public class StudyController {
 	@GetMapping(value = "/studylog/{studyId}")
 	public List<StudyLogResponseDto> getStudyLog(@PathVariable Integer studyId) {
 		return studyService.getStudyLog(studyId);
+	}
+
+	@ApiOperation(value = "스터디 생성", notes = "서버 시각 기준, 만들어진 Study Id 반환")
+	@PostMapping
+	public StudyResponseDto createStudy() {
+		JwtUserDetails userDetails = (JwtUserDetails)SecurityContextHolder.getContext()
+			.getAuthentication()
+			.getPrincipal();
+		return studyService.createStudy(userDetails);
+	}
+
+	@ApiOperation(value = "스터디 종료", notes = "서버 시각 기준 종료")
+	@PostMapping("/{studyId}/finish")
+	public StudyResponseDto finishStudy(@PathVariable Integer studyId) {
+		JwtUserDetails userDetails = (JwtUserDetails)SecurityContextHolder.getContext()
+			.getAuthentication()
+			.getPrincipal();
+		return studyService.finishStudy(userDetails, studyId);
+	}
+
+	@ApiOperation(value = "스터디 로그 삽입", notes = "기록 시각, 집중도를 싣어야 합니다")
+	@PostMapping("/{studyId}/push")
+	public StudyLogResponseDto pushStudyLog(@PathVariable Integer studyId,
+		@RequestBody StudyLogPostDto studyLogPostDto) {
+		JwtUserDetails userDetails = (JwtUserDetails)SecurityContextHolder.getContext()
+			.getAuthentication()
+			.getPrincipal();
+		return studyService.pushStudyLog(userDetails, studyId, studyLogPostDto);
 	}
 }

--- a/src/main/java/com/swp/study/domain/Study.java
+++ b/src/main/java/com/swp/study/domain/Study.java
@@ -37,13 +37,17 @@ public class Study extends CreatedAtEntity {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
+	@Column
+	private Double finalPercentage;
+
 	@Column(name = "end_at")
 	private LocalDateTime endAt;
 
 	@OneToMany(mappedBy = "study")
 	private List<StudyLog> studyLogList = new ArrayList<>();
 
-	public void finishStudy() {
+	public void finishStudy(Double percentage) {
+		this.finalPercentage = percentage;
 		this.endAt = LocalDateTime.now();
 	}
 

--- a/src/main/java/com/swp/study/domain/Study.java
+++ b/src/main/java/com/swp/study/domain/Study.java
@@ -1,18 +1,32 @@
 package com.swp.study.domain;
 
-import com.swp.user.domain.User;
-import lombok.Getter;
-import org.springframework.data.annotation.CreatedDate;
-
-import javax.persistence.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.OneToMany;
+import javax.persistence.Table;
+
+import com.swp.common.domain.CreatedAtEntity;
+import com.swp.user.domain.User;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
 @Entity
 @Table(name = "studies")
 @Getter
-public class Study {
+@NoArgsConstructor
+public class Study extends CreatedAtEntity {
 
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -23,13 +37,20 @@ public class Study {
 	@JoinColumn(name = "user_id", nullable = false)
 	private User user;
 
-	@Column(name = "start_at", nullable = false)
-	@CreatedDate
-	private LocalDateTime startAt;
-
 	@Column(name = "end_at")
 	private LocalDateTime endAt;
 
 	@OneToMany(mappedBy = "study")
 	private List<StudyLog> studyLogList = new ArrayList<>();
+
+	public void finishStudy() {
+		this.endAt = LocalDateTime.now();
+	}
+
+	@Builder
+	public Study(User user, LocalDateTime endAt) {
+		this.user = user;
+		this.endAt = endAt;
+	}
+
 }

--- a/src/main/java/com/swp/study/domain/StudyLog.java
+++ b/src/main/java/com/swp/study/domain/StudyLog.java
@@ -1,12 +1,15 @@
 package com.swp.study.domain;
 
+import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 
 @Entity
 @Table(name = "study_logs")
 @Getter
+@NoArgsConstructor
 public class StudyLog {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -22,4 +25,11 @@ public class StudyLog {
 
 	@Column(name = "percentage", nullable = false)
 	private Double percentage;
+
+	@Builder
+	public StudyLog(Study study, Long recordedTime, Double percentage) {
+		this.study = study;
+		this.recordedTime = recordedTime;
+		this.percentage = percentage;
+	}
 }

--- a/src/main/java/com/swp/study/domain/StudyService.java
+++ b/src/main/java/com/swp/study/domain/StudyService.java
@@ -1,25 +1,83 @@
 package com.swp.study.domain;
 
-
-import com.swp.study.Exception.StudyNotFoundException;
-import com.swp.study.dto.StudyLogResponseDto;
-import lombok.RequiredArgsConstructor;
-import org.springframework.stereotype.Service;
-
 import java.util.List;
 import java.util.stream.Collectors;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.swp.auth.dto.JwtUserDetails;
+import com.swp.study.Exception.StudyFinishedException;
+import com.swp.study.Exception.StudyNotFoundException;
+import com.swp.study.Exception.StudyUserNotMatchException;
+import com.swp.study.dto.StudyLogPostDto;
+import com.swp.study.dto.StudyLogResponseDto;
+import com.swp.study.dto.StudyResponseDto;
+import com.swp.user.domain.User;
+import com.swp.user.domain.UserRepository;
+import com.swp.user.exception.UserNotFoundException;
+
+import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
 public class StudyService {
 	private final StudyRepository studyRepository;
 	private final StudyLogRepository studyLogRepository;
+	private final UserRepository userRepository;
 
 	public List<StudyLogResponseDto> getStudyLog(Integer studyId) {
 		Study study = studyRepository.findById(studyId)
-				.orElseThrow(() -> new StudyNotFoundException("study 정보가 없습니다."));
+			.orElseThrow(() -> new StudyNotFoundException("study 정보가 없습니다."));
 		return studyLogRepository.findByStudy(study).stream()
-				.map(StudyLogResponseDto::from)
-				.collect(Collectors.toList());
+			.map(StudyLogResponseDto::from)
+			.collect(Collectors.toList());
+	}
+
+	@Transactional
+	public StudyResponseDto createStudy(JwtUserDetails userDetails) {
+		User user = userRepository.findByProviderAndProviderId(userDetails.getProvider(), userDetails.getUsername())
+			.orElseThrow(() -> new UserNotFoundException("없는 유저입니다"));
+
+		Study study = studyRepository.save(Study.builder().user(user).build());
+
+		return StudyResponseDto.from(study);
+	}
+
+	@Transactional
+	public StudyResponseDto finishStudy(JwtUserDetails userDetails, Integer studyId) {
+		Study study = getStudy(userDetails, studyId);
+		study.finishStudy();
+		return StudyResponseDto.from(study);
+	}
+
+	@Transactional
+	public StudyLogResponseDto pushStudyLog(JwtUserDetails userDetails, Integer studyId,
+		StudyLogPostDto studyLogPostDto) {
+		Study study = getStudy(userDetails, studyId);
+
+		StudyLog studyLog = studyLogRepository.save(StudyLog.builder()
+			.study(study)
+			.percentage(studyLogPostDto.getPercentage())
+			.recordedTime(studyLogPostDto.getRecordedTime())
+			.build());
+
+		return StudyLogResponseDto.from(studyLog);
+	}
+
+	private Study getStudy(JwtUserDetails userDetails, Integer studyId) {
+		User user = userRepository.findByProviderAndProviderId(userDetails.getProvider(), userDetails.getUsername())
+			.orElseThrow(() -> new UserNotFoundException("없는 유저입니다"));
+
+		Study study = studyRepository.findById(studyId)
+			.orElseThrow(() -> new StudyNotFoundException("study 정보가 없습니다."));
+
+		if (!study.getUser().equals(user))
+			throw new StudyUserNotMatchException();
+
+		if (study.getEndAt() != null)
+			throw new StudyFinishedException();
+
+		return study;
 	}
 }

--- a/src/main/java/com/swp/study/domain/StudyService.java
+++ b/src/main/java/com/swp/study/domain/StudyService.java
@@ -10,6 +10,7 @@ import com.swp.auth.dto.JwtUserDetails;
 import com.swp.study.Exception.StudyFinishedException;
 import com.swp.study.Exception.StudyNotFoundException;
 import com.swp.study.Exception.StudyUserNotMatchException;
+import com.swp.study.dto.StudyFinishDto;
 import com.swp.study.dto.StudyLogPostDto;
 import com.swp.study.dto.StudyLogResponseDto;
 import com.swp.study.dto.StudyResponseDto;
@@ -45,9 +46,9 @@ public class StudyService {
 	}
 
 	@Transactional
-	public StudyResponseDto finishStudy(JwtUserDetails userDetails, Integer studyId) {
+	public StudyResponseDto finishStudy(JwtUserDetails userDetails, Integer studyId, StudyFinishDto finishDto) {
 		Study study = getStudy(userDetails, studyId);
-		study.finishStudy();
+		study.finishStudy(finishDto.getFinalPercentage());
 		return StudyResponseDto.from(study);
 	}
 

--- a/src/main/java/com/swp/study/dto/StudyFinishDto.java
+++ b/src/main/java/com/swp/study/dto/StudyFinishDto.java
@@ -1,0 +1,15 @@
+package com.swp.study.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StudyFinishDto {
+
+	private Double finalPercentage;
+}

--- a/src/main/java/com/swp/study/dto/StudyLogPostDto.java
+++ b/src/main/java/com/swp/study/dto/StudyLogPostDto.java
@@ -1,0 +1,16 @@
+package com.swp.study.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Builder
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class StudyLogPostDto {
+
+	private Long recordedTime;
+	private Double percentage;
+}

--- a/src/main/java/com/swp/study/dto/StudyResponseDto.java
+++ b/src/main/java/com/swp/study/dto/StudyResponseDto.java
@@ -23,7 +23,7 @@ public class StudyResponseDto {
 	public static StudyResponseDto from(Study study) {
 		return StudyResponseDto.builder()
 				.studyId(study.getStudyId())
-				.startAt(study.getStartAt())
+				.startAt(study.getCreatedAt())
 				.endAt(study.getEndAt())
 				.build();
 	}

--- a/src/main/java/com/swp/study/dto/StudyResponseDto.java
+++ b/src/main/java/com/swp/study/dto/StudyResponseDto.java
@@ -1,13 +1,14 @@
 package com.swp.study.dto;
 
+import java.time.LocalDateTime;
+
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.swp.study.domain.Study;
+
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 @Data
 @NoArgsConstructor
@@ -15,6 +16,7 @@ import java.time.LocalDateTime;
 @Builder
 public class StudyResponseDto {
 	private Integer studyId;
+	private Double finalPercentage;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", locale = "Asia/Seoul")
 	private LocalDateTime startAt;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", locale = "Asia/Seoul")
@@ -22,9 +24,10 @@ public class StudyResponseDto {
 
 	public static StudyResponseDto from(Study study) {
 		return StudyResponseDto.builder()
-				.studyId(study.getStudyId())
-				.startAt(study.getCreatedAt())
-				.endAt(study.getEndAt())
-				.build();
+			.studyId(study.getStudyId())
+			.finalPercentage(study.getFinalPercentage())
+			.startAt(study.getCreatedAt())
+			.endAt(study.getEndAt())
+			.build();
 	}
 }


### PR DESCRIPTION
<img width="446" alt="스크린샷 2022-05-27 22 01 04" src="https://user-images.githubusercontent.com/39221443/170704276-36b68a70-bc0c-4e47-be94-a919994e421e.png">

ML 서비스를 위한 스터디 생성, 종료, 스터디 로그 삽입입니다.

DDL start_at -> created_at 으로 명칭 변경하였습니다.