### PR TITLE
fix: commentResponseDto에서 user 프로필 이미지와 이름 반환

### DIFF
--- a/src/main/java/com/swp/board/dto/CommentResponseDto.java
+++ b/src/main/java/com/swp/board/dto/CommentResponseDto.java
@@ -2,6 +2,7 @@ package com.swp.board.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.swp.board.domain.Comment;
+import com.swp.user.domain.User;
 import lombok.Builder;
 import lombok.Data;
 
@@ -14,6 +15,8 @@ public class CommentResponseDto {
 	private Integer commentId;
 	private Integer boardId;
 	private Integer userId;
+	private String nickname;
+	private String profileImage;
 	private String content;
 	@JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd HH:mm:ss", locale = "Asia/Seoul")
 	private LocalDateTime createdAt;
@@ -23,6 +26,8 @@ public class CommentResponseDto {
 			.commentId(comment.getCommentId())
 			.boardId(comment.getBoard().getBoardId())
 			.userId(comment.getUser().getId())
+			.nickname(comment.getUser().getNickname())
+			.profileImage(comment.getUser().getProfileImage())
 			.content(comment.getContent())
 			.createdAt(comment.getCreatedAt())
 			.build();

--- a/src/main/java/com/swp/board/dto/CommentResponseDto.java
+++ b/src/main/java/com/swp/board/dto/CommentResponseDto.java
@@ -2,7 +2,6 @@ package com.swp.board.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
 import com.swp.board.domain.Comment;
-import com.swp.user.domain.User;
 import lombok.Builder;
 import lombok.Data;
 


### PR DESCRIPTION
<img width="472" alt="image" src="https://user-images.githubusercontent.com/41511949/171354245-583e5b85-6986-42b8-8c71-2aea9e751e6b.png">

<img width="1047" alt="image" src="https://user-images.githubusercontent.com/41511949/171354713-4992a206-3d1f-4fb1-b99e-304b33b6ae63.png">


comment response에 댓글을 쓴 유저의 이름(nickname)과, 프로필 이미지 주소도 같이 response 하도록 고쳤습니다. 
